### PR TITLE
chore(security): upgrade dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Version 1.2.1](https://github.com/mathrix-education/setup-gcloud/releases/tag/1.2.1)
 - **chore**(deps): bumps lodash from 4.17.15 to 4.17.19 (fixes GHSA-p6mc-m468-83gw)
+- **chore**(repo): rename `master` branch to `main`
 
 ## [Version 1.2.0 - Local SDK](https://github.com/mathrix-education/setup-gcloud/releases/tag/1.2.0)
 - **feat**: add `local` for `version` input which will use the locally provided Google Cloud SDK if available

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [Version 1.2.1](https://github.com/mathrix-education/setup-gcloud/releases/tag/1.2.1)
+- **chore**(deps): bumps lodash from 4.17.15 to 4.17.19 (fixes GHSA-p6mc-m468-83gw)
+
 ## [Version 1.2.0 - Local SDK](https://github.com/mathrix-education/setup-gcloud/releases/tag/1.2.0)
 - **feat**: add `local` for `version` input which will use the locally provided Google Cloud SDK if available
 - **chore**(deps): upgrade dependencies

--- a/dist/index.js
+++ b/dist/index.js
@@ -3384,6 +3384,7 @@ class HTTPError extends Error {
 }
 exports.HTTPError = HTTPError;
 const IS_WINDOWS = process.platform === 'win32';
+const IS_MAC = process.platform === 'darwin';
 const userAgent = 'actions/tool-cache';
 /**
  * Download a tool from an url and stream it into a file
@@ -3599,6 +3600,36 @@ function extractTar(file, dest, flags = 'xz') {
     });
 }
 exports.extractTar = extractTar;
+/**
+ * Extract a xar compatible archive
+ *
+ * @param file     path to the archive
+ * @param dest     destination directory. Optional.
+ * @param flags    flags for the xar. Optional.
+ * @returns        path to the destination directory
+ */
+function extractXar(file, dest, flags = []) {
+    return __awaiter(this, void 0, void 0, function* () {
+        assert_1.ok(IS_MAC, 'extractXar() not supported on current OS');
+        assert_1.ok(file, 'parameter "file" is required');
+        dest = yield _createExtractFolder(dest);
+        let args;
+        if (flags instanceof Array) {
+            args = flags;
+        }
+        else {
+            args = [flags];
+        }
+        args.push('-x', '-C', dest, '-f', file);
+        if (core.isDebug()) {
+            args.push('-v');
+        }
+        const xarPath = yield io.which('xar', true);
+        yield exec_1.exec(`"${xarPath}"`, _unique(args));
+        return dest;
+    });
+}
+exports.extractXar = extractXar;
 /**
  * Extract a zip
  *
@@ -3906,6 +3937,13 @@ function _getGlobal(key, defaultValue) {
     const value = global[key];
     /* eslint-enable @typescript-eslint/no-explicit-any */
     return value !== undefined ? value : defaultValue;
+}
+/**
+ * Returns an array of unique values.
+ * @param values Values to make unique.
+ */
+function _unique(values) {
+    return Array.from(new Set(values));
 }
 //# sourceMappingURL=tool-cache.js.map
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@mathrix-education/setup-gcloud",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@mathrix-education/setup-gcloud",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -31,9 +31,9 @@
       "integrity": "sha512-J8KuFqVPr3p6U8W93DOXlXW6zFvrQAJANdS+vw0YhusLIq+bszW8zmK2Fh1C2kDPX8FMvwIl1OUcFgvJoXLbAg=="
     },
     "@actions/tool-cache": {
-      "version": "1.5.5",
-      "resolved": "https://registry.npmjs.org/@actions/tool-cache/-/tool-cache-1.5.5.tgz",
-      "integrity": "sha512-y/YO37BOaXzOEHpvoGZDLCwvg6XZWQ7Ala4Np4xzrKD1r48mff+K/GAmzXMejnApU7kgqC6lL/aCKTZDCrhdmw==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@actions/tool-cache/-/tool-cache-1.6.0.tgz",
+      "integrity": "sha512-+fyEBImPD3m5I0o6DflCO0NHY180LPoX8Lo6y4Iez+V17kO8kfkH0VHxb8mUdmD6hn9dWA9Ch1JA20fXoIYUeQ==",
       "requires": {
         "@actions/core": "^1.2.3",
         "@actions/exec": "^1.0.0",
@@ -82,9 +82,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "12.12.48",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.48.tgz",
-      "integrity": "sha512-m3Nmo/YaDUfYzdCQlxjF5pIy7TNyDTAJhIa//xtHcF0dlgYIBKULKnmloCPtByDxtZXrWV8Pge1AKT6/lRvVWg==",
+      "version": "12.12.50",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.50.tgz",
+      "integrity": "sha512-5ImO01Fb8YsEOYpV+aeyGYztcYcjGsBvN4D7G5r1ef2cuQOpymjWNQi5V0rKHE6PC2ru3HkoUr/Br2/8GUA84w==",
       "dev": true
     },
     "@types/normalize-package-data": {
@@ -1052,9 +1052,9 @@
       "dev": true
     },
     "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+      "version": "4.17.19",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
       "dev": true
     },
     "mimic-fn": {
@@ -1652,9 +1652,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "3.9.6",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.6.tgz",
-      "integrity": "sha512-Pspx3oKAPJtjNwE92YS05HQoY7z2SFyOpHo9MqJor3BXAGNaPUs83CuVp9VISFkSjyRfiTpmKuAYGJB7S7hOxw=="
+      "version": "3.9.7",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
+      "integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw=="
     },
     "uri-js": {
       "version": "4.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mathrix-education/setup-gcloud",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Install the Google Cloud SDK in your GitHub Actions workflow.",
   "keywords": [
     "github-actions",

--- a/package.json
+++ b/package.json
@@ -31,12 +31,12 @@
   "dependencies": {
     "@actions/core": "^1.2.4",
     "@actions/exec": "^1.0.4",
-    "@actions/tool-cache": "^1.5.5",
+    "@actions/tool-cache": "^1.6.0",
     "original-fs": "^1.1.0",
-    "typescript": "^3.9.6"
+    "typescript": "^3.9.7"
   },
   "devDependencies": {
-    "@types/node": "^12.12.48",
+    "@types/node": "^12.12.50",
     "@typescript-eslint/eslint-plugin": "^2.34.0",
     "@typescript-eslint/parser": "^2.34.0",
     "@zeit/ncc": "^0.22.3",


### PR DESCRIPTION
Bumps lodash from 4.17.15 to 4.17.19, as suggested by @dependabot in PR #17 (fixes GHSA-p6mc-m468-83gw)